### PR TITLE
added alphabetize rule to linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "max-len": ["error", { "code": 120 }],
     "consistent-return": "error",
     "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 1 }],
-    "no-unused-vars": ["error", { "varsIgnorePattern": "^_" }]
+    "no-unused-vars": ["error", { "varsIgnorePattern": "^_" }],
+    "import/order": ["error", { "alphabetize": { "order": "asc" } }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "format": "yarn run lint --fix",
     "test": "vitest",
     "prod": "node .next/standalone/server.js"
   },

--- a/src/app/components/PokemonList/PokemonList.test.tsx
+++ b/src/app/components/PokemonList/PokemonList.test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import PokemonList from "../PokemonList/PokemonList";
 
 describe("PokemonList", () => {

--- a/src/app/components/PokemonList/PokemonList.tsx
+++ b/src/app/components/PokemonList/PokemonList.tsx
@@ -1,6 +1,6 @@
+import Image from "next/image";
 import Link from "next/link";
 import { MappedPokemon } from "@/types";
-import Image from "next/image";
 
 const PokemonList = ({ pokemonList }: { pokemonList: MappedPokemon[] }) => {
   return (

--- a/src/app/components/PokemonPage/PokemonPage.tsx
+++ b/src/app/components/PokemonPage/PokemonPage.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { PokemonAbility } from "@/app/components";
-import { MappedPokemon } from "@/types";
 import {
   fetchPokemon,
   getTypes,
@@ -8,6 +7,7 @@ import {
   getNormalAbility,
   getHiddenAbility,
 } from "@/helpers";
+import { MappedPokemon } from "@/types";
 
 const formatName = (nameWithDash: string) => nameWithDash.replace("-", " ");
 


### PR DESCRIPTION
### Context

I have added a bootcamp student to the project for her to see what it will be like when she gets into a real team env. 

Note: PR reviews now required. 

### Changes Made

- Added the `import/order` rule to our ESLint configuration.
- Configured the rule to enforce alphabetical order (`"alphabetize": { "order": "asc" }`) for imports.
- Checked and updated import statements throughout the project to adhere to the new rule.

### Rationale

The addition of this rule is driven by the need for consistency in our codebase, especially as we onboard new developers. It ensures that imports are organized in a clear and predictable manner, simplifying the development and review process for everyone involved.



### Checklist

- [ ] Verified that all existing imports have been organized in alphabetical order.
- [ ] Checked that ESLint is properly configured with the new rule.
- [ ] Ran ESLint to confirm that the code complies with the updated rule.
- [ ] Discussed and obtained feedback from team members on the changes.

Your feedback and reviews are greatly appreciated as we strive to uphold coding best practices and consistency within our project. Thank you for your collaboration!
