### PR TITLE
skip

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,5 +1,5 @@
-# example 2: on merge to master from pull request (recommended)
 name: Bump version
+
 on:
   pull_request:
     types:
@@ -19,10 +19,20 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: "0"
 
+      - name: Check for #skip in commit message
+        id: check_skip
+        run: |
+          if git log --format=%B -n 1 $GITHUB_SHA | grep -q "#skip"; then
+            echo "Found #skip in commit message. Skipping deployment and tagging."
+            exit 1
+          fi
+        shell: bash
+
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.64.0 # Don't use @master or @v1 unless you're happy to test the latest version
+        if: steps.check_skip.outcome != 'failure' # Only run if the previous step didn't find #skip
+        uses: anothrNick/github-tag-action@1.64.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # if you don't want to set write permissions use a PAT token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           PRERELEASE: true
           DEFAULT_BUMP: patch


### PR DESCRIPTION
Modify your setup so that if a commit message in a pull request contains #skip, the merge will not be deployed to production and it is not tagged with a version number.

tag before merge: [v0.0.1-beta.0]