### PR TITLE
added webhook

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,30 @@
+name: Build Notification
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Notify on success
+        if: success()
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          details: Build Succeeded!
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: error
+          details: Build Failed! Check the latest commit.
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
## Implementing Discord Webhook Notification in GitHub Actions
#### This is new to me so I am not sure if I have done it correctly. I have added the secret into setting -> secrets and the webhook into settings -> webook -> url

I've just completed Exercise 11.18 from the Full Stack Open course, which involved setting up Discord webhook notifications for GitHub Actions. You can check out the exercise [here](https://fullstackopen.com/en/part11/expanding_further).

To achieve this, I made use of the [Discord Webhook Notify action](https://github.com/marketplace/actions/discord-webhook-notify), which allows me to send notifications to a Discord channel using a webhook URL. It's a great way to keep track of build status and deployment success or failure.

The setup process involved creating a Discord webhook, adding it as a secret in my GitHub project settings, and configuring the action in my workflow YAML file. Now, I can receive notifications about build success and failures, making it easier to identify issues quickly.

If you're interested in implementing Discord webhook notifications in your GitHub Actions workflows, I highly recommend checking out the action mentioned above. It's a straightforward way to improve visibility and communication in your development process.


